### PR TITLE
Debian buster update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7
 RUN pip install pipenv
 RUN apt update
-RUN apt install -y mysql-client
+RUN apt install -y mariadb-client
 ADD . /code
 WORKDIR /code
 RUN pipenv install


### PR DESCRIPTION
python:3.7 image is based on debian:buster and it has not access to mysql-client instead of this, buster can access to mariadb-client, check it in this [StackOverflow Question](https://stackoverflow.com/questions/57048428/e-package-mysql-client-has-no-installation-candidate-in-php-fpm-image-build-u)